### PR TITLE
Added: close the Serial Port Object on exit

### DIFF
--- a/ControllingStimulatorExample.m
+++ b/ControllingStimulatorExample.m
@@ -158,7 +158,7 @@ while ~loopUntilEscape
                 display 'Stimulator is disarmed';
             end
             loopUntilEscape = 1;
-
+            fclose(serialPortObj);
             return;
 
         end


### PR DESCRIPTION
This will make the serial port available for another run of _ControllingStimulatorExample.m_ or something else without closing Matlab. This will also stop the Timer Function `TimerFcn = {'Rapid2_MaintainCommunication'};`